### PR TITLE
`ArtifactKind` could support `daft::Diffable`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "daft"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a75caf1eeef382d47bf5d3012b5ec521311cd876a1304ac8807ec86d4df42a7"
+dependencies = [
+ "daft-derive",
+ "paste",
+]
+
+[[package]]
+name = "daft-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a851e4efac7afda4a5e1a11fea1d65ef528dbdcff08177d7087e4bb6225e60a9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "datatest-stable"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3389,6 +3410,7 @@ dependencies = [
 name = "tufaceous-artifact"
 version = "0.1.0"
 dependencies = [
+ "daft",
  "parse-display",
  "proptest",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ camino-tempfile = "1.1.1"
 chrono = { version = "0.4.40", default-features = false, features = ["std"] }
 clap = { version = "4.5.31", features = ["cargo", "derive", "env", "wrap_help"] }
 console = { version = "0.15.10", default-features = false }
+daft = { version = "0.1.1", features = ["derive"] }
 datatest-stable = "0.2.9"
 debug-ignore = "1.0.5"
 dropshot = "0.15.1"

--- a/artifact/Cargo.toml
+++ b/artifact/Cargo.toml
@@ -10,6 +10,7 @@ proptest = ["dep:proptest", "dep:test-strategy"]
 schemars = ["dep:schemars"]
 
 [dependencies]
+daft.workspace = true
 parse-display.workspace = true
 proptest = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }

--- a/artifact/src/lib.rs
+++ b/artifact/src/lib.rs
@@ -7,6 +7,7 @@ use std::convert::Infallible;
 use std::fmt;
 use std::str::FromStr;
 
+use daft::Diffable;
 use parse_display::{Display, FromStr};
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -58,7 +59,7 @@ pub struct Artifact {
 /// around a string. The set of known artifact kinds is described in
 /// [`KnownArtifactKind`], and this type has conversions to and from it.
 #[derive(
-    Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Deserialize, Serialize,
+    Debug, Diffable, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Deserialize, Serialize,
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(transparent)]

--- a/artifact/src/lib.rs
+++ b/artifact/src/lib.rs
@@ -59,7 +59,16 @@ pub struct Artifact {
 /// around a string. The set of known artifact kinds is described in
 /// [`KnownArtifactKind`], and this type has conversions to and from it.
 #[derive(
-    Debug, Diffable, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Deserialize, Serialize,
+    Debug,
+    Diffable,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Ord,
+    PartialOrd,
+    Deserialize,
+    Serialize,
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(transparent)]


### PR DESCRIPTION
This is wanted for oxidecomputer/omicron#7741, which adds `ArtifactKind` to the blueprint (and so needs to be `Diffable`).