### PR TITLE
[5/n] allow adding non-semver artifacts with --allow-non-semver

### DIFF
--- a/bin/manifests/fake-non-semver.toml
+++ b/bin/manifests/fake-non-semver.toml
@@ -1,0 +1,88 @@
+# This is an artifact manifest that generates fake entries for all components.
+# Some of the components have non-semver artifact versions.
+# 
+# This is completely non-functional and is only useful for testing archive
+# extraction in other parts of the repository.
+
+system_version = "1.0.0"
+
+[[artifact.gimlet_sp]]
+name = "fake-gimlet-sp"
+version = "1.0.0"
+source = { kind = "fake", size = "1MiB" }
+
+[[artifact.gimlet_rot]]
+name = "fake-gimlet-rot"
+version = "1.0.0"
+[artifact.gimlet_rot.source]
+kind = "composite-rot"
+archive_a = { kind = "fake", size = "512KiB" }
+archive_b = { kind = "fake", size = "512KiB" }
+
+[[artifact.host]]
+name = "fake-host"
+version = "1.0.0"
+[artifact.host.source]
+kind = "composite-host"
+phase_1 = { kind = "fake", size = "512KiB" }
+phase_2 = { kind = "fake", size = "1MiB" }
+
+[[artifact.trampoline]]
+name = "fake-trampoline"
+version = "non-semver"
+[artifact.trampoline.source]
+kind = "composite-host"
+phase_1 = { kind = "fake", size = "512KiB" }
+phase_2 = { kind = "fake", size = "1MiB" }
+
+[[artifact.control_plane]]
+name = "fake-control-plane"
+version = "1.0.0"
+[artifact.control_plane.source]
+kind = "composite-control-plane"
+zones = [
+    { kind = "fake", name = "zone1", size = "1MiB" },
+    { kind = "fake", name = "zone2", size = "1MiB" },
+]
+
+[[artifact.psc_sp]]
+name = "fake-psc-sp"
+version = "1.0.0"
+source = { kind = "fake", size = "1MiB" }
+
+[[artifact.psc_rot]]
+name = "fake-psc-rot"
+version = "1.0.0"
+[artifact.psc_rot.source]
+kind = "composite-rot"
+archive_a = { kind = "fake", size = "512KiB" }
+archive_b = { kind = "fake", size = "512KiB" }
+
+[[artifact.switch_sp]]
+name = "fake-switch-sp"
+version = "1.0.0"
+source = { kind = "fake", size = "1MiB" }
+
+[[artifact.switch_rot]]
+name = "fake-switch-rot"
+version = "1.0.0"
+[artifact.switch_rot.source]
+kind = "composite-rot"
+archive_a = { kind = "fake", size = "512KiB" }
+archive_b = { kind = "fake", size = "512KiB" }
+
+[[artifact.gimlet_rot_bootloader]]
+name = "fake-gimlet-rot-bootloader"
+version = "1.0.0"
+source = { kind = "fake", size = "1MiB" }
+
+[[artifact.psc_rot_bootloader]]
+name = "fake-psc-rot-bootloader"
+version = "1.0.0"
+source = { kind = "fake", size = "1MiB" }
+
+[[artifact.switch_rot_bootloader]]
+name = "fake-switch-rot-bootloader"
+version = "non-semver-2"
+source = { kind = "fake", size = "1MiB" }
+

--- a/bin/manifests/fake-non-semver.toml
+++ b/bin/manifests/fake-non-semver.toml
@@ -1,19 +1,19 @@
 # This is an artifact manifest that generates fake entries for all components.
 # Some of the components have non-semver artifact versions.
-# 
+#
 # This is completely non-functional and is only useful for testing archive
 # extraction in other parts of the repository.
 
-system_version = "1.0.0"
+system_version = "2.0.0"
 
 [[artifact.gimlet_sp]]
 name = "fake-gimlet-sp"
-version = "1.0.0"
+version = "2.0.0"
 source = { kind = "fake", size = "1MiB" }
 
 [[artifact.gimlet_rot]]
 name = "fake-gimlet-rot"
-version = "1.0.0"
+version = "2.0.0"
 [artifact.gimlet_rot.source]
 kind = "composite-rot"
 archive_a = { kind = "fake", size = "512KiB" }
@@ -21,7 +21,7 @@ archive_b = { kind = "fake", size = "512KiB" }
 
 [[artifact.host]]
 name = "fake-host"
-version = "1.0.0"
+version = "2.0.0"
 [artifact.host.source]
 kind = "composite-host"
 phase_1 = { kind = "fake", size = "512KiB" }
@@ -37,7 +37,7 @@ phase_2 = { kind = "fake", size = "1MiB" }
 
 [[artifact.control_plane]]
 name = "fake-control-plane"
-version = "1.0.0"
+version = "2.0.0"
 [artifact.control_plane.source]
 kind = "composite-control-plane"
 zones = [
@@ -47,12 +47,12 @@ zones = [
 
 [[artifact.psc_sp]]
 name = "fake-psc-sp"
-version = "1.0.0"
+version = "2.0.0"
 source = { kind = "fake", size = "1MiB" }
 
 [[artifact.psc_rot]]
 name = "fake-psc-rot"
-version = "1.0.0"
+version = "2.0.0"
 [artifact.psc_rot.source]
 kind = "composite-rot"
 archive_a = { kind = "fake", size = "512KiB" }
@@ -60,12 +60,12 @@ archive_b = { kind = "fake", size = "512KiB" }
 
 [[artifact.switch_sp]]
 name = "fake-switch-sp"
-version = "1.0.0"
+version = "2.0.0"
 source = { kind = "fake", size = "1MiB" }
 
 [[artifact.switch_rot]]
 name = "fake-switch-rot"
-version = "1.0.0"
+version = "2.0.0"
 [artifact.switch_rot.source]
 kind = "composite-rot"
 archive_a = { kind = "fake", size = "512KiB" }
@@ -73,16 +73,15 @@ archive_b = { kind = "fake", size = "512KiB" }
 
 [[artifact.gimlet_rot_bootloader]]
 name = "fake-gimlet-rot-bootloader"
-version = "1.0.0"
+version = "2.0.0"
 source = { kind = "fake", size = "1MiB" }
 
 [[artifact.psc_rot_bootloader]]
 name = "fake-psc-rot-bootloader"
-version = "1.0.0"
+version = "2.0.0"
 source = { kind = "fake", size = "1MiB" }
 
 [[artifact.switch_rot_bootloader]]
 name = "fake-switch-rot-bootloader"
 version = "non-semver-2"
 source = { kind = "fake", size = "1MiB" }
-

--- a/lib/src/artifact.rs
+++ b/lib/src/artifact.rs
@@ -10,8 +10,7 @@ use buf_list::BufList;
 use bytes::Bytes;
 use camino::Utf8PathBuf;
 use fs_err::File;
-use semver::Version;
-use tufaceous_artifact::ArtifactKind;
+use tufaceous_artifact::{ArtifactKind, ArtifactVersion};
 use tufaceous_brand_metadata::Metadata;
 
 mod composite;
@@ -34,11 +33,7 @@ pub enum ArtifactSource {
 pub struct AddArtifact {
     kind: ArtifactKind,
     name: String,
-    // Note: for now we accept a `semver::Version`, because we're in a
-    // transitional period where the currently-installed version of Oxide system
-    // software (v13) requires that artifact versions are semver. We can relax
-    // this and accept `ArtifactVersion` after v14 is released.
-    version: Version,
+    version: ArtifactVersion,
     source: ArtifactSource,
 }
 
@@ -47,7 +42,7 @@ impl AddArtifact {
     pub fn new(
         kind: ArtifactKind,
         name: String,
-        version: Version,
+        version: ArtifactVersion,
         source: ArtifactSource,
     ) -> Self {
         Self { kind, name, version, source }
@@ -60,7 +55,7 @@ impl AddArtifact {
     pub fn from_path(
         kind: ArtifactKind,
         name: Option<String>,
-        version: Version,
+        version: ArtifactVersion,
         path: Utf8PathBuf,
     ) -> Result<Self> {
         let name = match name {
@@ -88,7 +83,7 @@ impl AddArtifact {
     }
 
     /// Returns the version of the new artifact.
-    pub fn version(&self) -> &Version {
+    pub fn version(&self) -> &ArtifactVersion {
         &self.version
     }
 

--- a/lib/src/assemble/manifest.rs
+++ b/lib/src/assemble/manifest.rs
@@ -335,7 +335,7 @@ pub struct ArtifactDataDisplay<'a> {
     data: &'a ArtifactData,
 }
 
-impl<'a> fmt::Display for ArtifactDataDisplay<'a> {
+impl fmt::Display for ArtifactDataDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} ({})", self.data.name, self.data.version)
     }


### PR DESCRIPTION
While adding tests to Omicron, I realized that it would be useful for tests to have a way to add non-semver artifacts. This does require tufaceous-lib users like our releng tooling to ensure they're calling the verification function, but I don't think that's too bad for now -- and it's temporary anyway.
