### PR TITLE
drop `rust-version` from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 publish = false
-rust-version = "1.85"
 
 [workspace.dependencies]
 anyhow = "1.0.96"

--- a/artifact/Cargo.toml
+++ b/artifact/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 publish.workspace = true
-rust-version.workspace = true
 
 [features]
 proptest = ["dep:proptest", "dep:test-strategy"]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 publish.workspace = true
-rust-version.workspace = true
 
 [[test]]
 name = "manifest-tests"

--- a/brand-metadata/Cargo.toml
+++ b/brand-metadata/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 publish.workspace = true
-rust-version.workspace = true
 
 [dependencies]
 semver.workspace = true

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 publish.workspace = true
-rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
Originally added in #9.

tufaceous builds fine on e.g. Rust 1.84.0. An incorrect rust-toolchain entry confuses crates downstream of Omicron that are on an older Rust toolchain, and isn't necessary to use the new style edition; that comes along with `rust-toolchain.toml`.