### PR TITLE
[0/n] [tufaceous-brand-metadata] use ArtifactVersion for versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3460,6 +3460,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
+ "tufaceous-artifact",
 ]
 
 [[package]]

--- a/brand-metadata/Cargo.toml
+++ b/brand-metadata/Cargo.toml
@@ -10,6 +10,7 @@ semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tar.workspace = true
+tufaceous-artifact.workspace = true
 
 [lints]
 workspace = true

--- a/brand-metadata/src/lib.rs
+++ b/brand-metadata/src/lib.rs
@@ -12,6 +12,7 @@
 use std::io::{Error, ErrorKind, Read, Result, Write};
 
 use serde::{Deserialize, Serialize};
+use tufaceous_artifact::ArtifactVersion;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Metadata {
@@ -42,7 +43,7 @@ pub enum ArchiveType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct LayerInfo {
     pub pkg: String,
-    pub version: semver::Version,
+    pub version: ArtifactVersion,
 }
 
 impl Metadata {

--- a/lib/src/assemble/manifest.rs
+++ b/lib/src/assemble/manifest.rs
@@ -600,7 +600,8 @@ impl DeserializedControlPlaneZoneSource {
 
                 let metadata = Metadata::new(ArchiveType::Layer(LayerInfo {
                     pkg: name.clone(),
-                    version: semver::Version::new(0, 0, 0),
+                    // TODO: replace with `ArtifactVersion` once it's passed in
+                    version: ArtifactVersion::new_const("0.0.0"),
                 }));
                 metadata.append_to_tar(&mut tar, 0)?;
 


### PR DESCRIPTION
Missed this during the conversion to freeform identifiers.
