### PR TITLE
preserve requested formatting in some Display impls

### DIFF
--- a/artifact/src/artifact.rs
+++ b/artifact/src/artifact.rs
@@ -82,7 +82,7 @@ impl fmt::Debug for ArtifactHash {
 
 impl fmt::Display for ArtifactHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&hex::encode(self.0))
+        hex::encode(self.0).fmt(f)
     }
 }
 

--- a/artifact/src/kind.rs
+++ b/artifact/src/kind.rs
@@ -144,7 +144,7 @@ impl From<KnownArtifactKind> for ArtifactKind {
 
 impl fmt::Display for ArtifactKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
+        self.0.fmt(f)
     }
 }
 

--- a/artifact/src/version.rs
+++ b/artifact/src/version.rs
@@ -106,7 +106,7 @@ impl FromStr for ArtifactVersion {
 
 impl fmt::Display for ArtifactVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
+        self.as_str().fmt(f)
     }
 }
 


### PR DESCRIPTION
I'm writing some tooling with this and noticed that when I formatted `ArtifactVersion` and `ArtifactKind` into fixed-width fields, the width wasn't being honored.  I guess this is the way you're supposed to delegate `Display`?  Here's a playground that shows the problem outside of tufaceous:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=80fe4b1d5e37fb96f2abd500722bc36a

There are other impls in tufaceous that I didn't fix because they weren't in my way and it was not obvious how best to do it.