### PR TITLE
update zip to 4.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3483,7 +3483,7 @@ dependencies = [
  "tufaceous-artifact",
  "tufaceous-brand-metadata",
  "url",
- "zip 2.6.0",
+ "zip 4.2.0",
 ]
 
 [[package]]
@@ -4106,13 +4106,12 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.6.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "febbe83a485467affa75a75d28dc7494acd2f819e549536c47d46b3089b56164"
+checksum = "95ab361742de920c5535880f89bbd611ee62002bf11341d16a5f057bb8ba6899"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "crossbeam-utils",
  "indexmap 2.7.1",
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,6 @@ tufaceous-artifact = { path = "artifact", default-features = false }
 tufaceous-brand-metadata = { path = "brand-metadata" }
 tufaceous-lib = { path = "lib" }
 url = "2.5.3"
-zip = { version = "2.6.0", default-features = false }
+zip = { version = "4.2.0", default-features = false }
 
 [workspace.lints.clippy]


### PR DESCRIPTION
The zip crate's versions 2.6.0 and 2.6.1 were yanked from crates.io: https://github.com/zip-rs/zip2/issues/337

This is currently causing rust-analyzer to barf on Omicron while trying to
fetch `cargo metadata`:

```
% RUSTC_BOOTSTRAP=1 /opt/rustup/toolchains/1.87.0-x86_64-unknown-linux-gnu/bin/cargo metadata --format-version 1 --manifest-path /home/rain/dev/oxide/omicron/Cargo.toml --filter-platform x86_64-unknown-linux-gnu --lockfile-path /home/rain/dev/oxide/omicron/target/rust-analyzer/metadata/workspace/Cargo.lock -Zunstable-options
    Updating git repository `https://github.com/oxidecomputer/pq-sys`
    Updating crates.io index
    Updating git repository `https://github.com/oxidecomputer/lldp`
    Updating git repository `https://github.com/oxidecomputer/maghemite`
    Updating git repository `https://github.com/oxidecomputer/serde_human_bytes`
    Updating git repository `https://github.com/oxidecomputer/slog-error-chain`
    Updating git repository `https://github.com/oxidecomputer/tufaceous`
    Updating git repository `https://github.com/oxidecomputer/propolis`
    Updating git repository `https://github.com/oxidecomputer/crucible`
    Updating git repository `https://github.com/oxidecomputer/opte`
    Updating git repository `https://github.com/oxidecomputer/falcon`
    Updating git repository `https://github.com/oxidecomputer/clickward`
    Updating git repository `https://github.com/oxidecomputer/openapi-lint`
    Updating git repository `https://github.com/oxidecomputer/management-gateway-service`
    Updating git repository `https://github.com/oxidecomputer/ipcc-rs`
    Updating git repository `https://github.com/oxidecomputer/dendrite`
    Updating git repository `https://github.com/oxidecomputer/transceiver-control`
    Updating git repository `https://github.com/oxidecomputer/hubtools.git`
    Updating git repository `https://github.com/oxidecomputer/sprockets.git`
    Updating git repository `https://github.com/oxidecomputer/tofino`
    Updating git repository `https://github.com/oxidecomputer/illumos-devinfo`
    Updating git repository `https://github.com/oxidecomputer/libefi-illumos`
    Updating git repository `https://github.com/oxidecomputer/libnvme`
    Updating git repository `https://github.com/bluecatengineering/dhcproto.git`
    Updating git repository `https://github.com/oxidecomputer/ispf`
    Updating git repository `https://github.com/oxidecomputer/netadm-sys`
    Updating git repository `https://github.com/oxidecomputer/propolis`
    Updating git repository `https://github.com/oxidecomputer/transceiver-control`
    Updating git repository `https://github.com/oxidecomputer/tlvc.git`
    Updating git repository `https://github.com/oxidecomputer/lpc55_support`
    Updating git repository `https://github.com/oxidecomputer/tlvc`
    Updating git repository `https://github.com/oxidecomputer/dice-util`
error: failed to select a version for the requirement `zip = "^2.6.0"`
  version 2.6.0 is yanked
  version 2.6.1 is yanked
location searched: crates.io index
required by package `tufaceous-lib v0.1.0 (https://github.com/oxidecomputer/tufaceous?branch=main#04681f26)`
    ... which satisfies git dependency `tufaceous-lib` of package `omicron-nexus v0.1.0 (/home/rain/dev/oxide/omicron/nexus)`
    ... which satisfies path dependency `omicron-nexus` of package `omicron-omdb v0.1.0 (/home/rain/dev/oxide/omicron/dev-tools/omdb)`
```
