### PR TITLE
for composite control plane artifacts, define both artifact name and file name

### DIFF
--- a/bin/invalid-manifests/duplicate-zone-file-name.toml
+++ b/bin/invalid-manifests/duplicate-zone-file-name.toml
@@ -9,6 +9,6 @@ version = "1.0.0"
 [artifact.control_plane.source]
 kind = "composite-control-plane"
 zones = [
-    { kind = "fake", name = "zone1", size = "1MiB" },
-    { kind = "fake", name = "zone1", size = "1MiB" },
+    { kind = "fake", artifact_name = "zone-1", file_name = "zone1.tar.gz", size = "1MiB" },
+    { kind = "fake", artifact_name = "zone-1", file_name = "zone1-dup.tar.gz", size = "1MiB" },
 ]

--- a/bin/manifests/fake-non-semver.toml
+++ b/bin/manifests/fake-non-semver.toml
@@ -41,8 +41,8 @@ version = "2.0.0"
 [artifact.control_plane.source]
 kind = "composite-control-plane"
 zones = [
-    { kind = "fake", name = "zone1", size = "1MiB" },
-    { kind = "fake", name = "zone2", size = "1MiB" },
+    { kind = "fake", artifact_name = "zone-1", file_name = "zone1.tar.gz", size = "1MiB" },
+    { kind = "fake", artifact_name = "zone-2", file_name = "zone2.tar.gz", size = "1MiB" },
 ]
 
 [[artifact.psc_sp]]

--- a/bin/manifests/fake.toml
+++ b/bin/manifests/fake.toml
@@ -39,8 +39,8 @@ version = "1.0.0"
 [artifact.control_plane.source]
 kind = "composite-control-plane"
 zones = [
-    { kind = "fake", name = "zone1", size = "1MiB" },
-    { kind = "fake", name = "zone2", size = "1MiB" },
+    { kind = "fake", artifact_name = "zone-1", file_name = "zone1.tar.gz", size = "1MiB" },
+    { kind = "fake", artifact_name = "zone-2", file_name = "zone2.tar.gz", size = "1MiB" },
 ]
 
 [[artifact.psc_sp]]

--- a/bin/tests/integration-tests/command_tests.rs
+++ b/bin/tests/integration-tests/command_tests.rs
@@ -240,7 +240,8 @@ fn test_assemble_duplicate_zone() -> Result<()> {
     cmd.args([
         "assemble",
         "--skip-all-present",
-        "invalid-manifests/duplicate-zone.toml",
+        // TODO: should we also check duplicate zone artifact names?
+        "invalid-manifests/duplicate-zone-file-name.toml",
     ]);
     cmd.arg(&archive_path);
     cmd.assert()
@@ -250,7 +251,7 @@ fn test_assemble_duplicate_zone() -> Result<()> {
         ))
         .stderr(predicate::str::contains("zone/"))
         .stderr(predicate::str::contains(
-            r#"(existing name: zone1.tar.gz, version: 1.0.0; new name: zone1.tar.gz, version: 1.0.0)"#,
+            r#"(existing name: zone1.tar.gz, version: 1.0.0; new name: zone1-dup.tar.gz, version: 1.0.0)"#,
         ));
 
     logctx.cleanup_successful();


### PR DESCRIPTION
In https://github.com/oxidecomputer/omicron/pull/8514 we found that the artifact and file names don't actually match all the time. With this change, both the artifact and the file name will have to be specified.

https://github.com/oxidecomputer/omicron/issues/8510 is the issue that tracks cleaning this up.