### PR TITLE
avoid rejecting repositories too early

### DIFF
--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -136,7 +136,7 @@ impl OmicronRepo {
                 Err(
                     err @ (Error::VerifyMetadata { .. }
                     | Error::VerifyTrustedMetadata { .. }),
-                ) if verify_error.is_none() => {
+                ) => {
                     verify_error = Some(err.into());
                     continue;
                 }
@@ -631,6 +631,11 @@ mod tests {
             vec![trusted_root.buffer(), untrusted_root.buffer()],
             vec![untrusted_root.buffer(), trusted_root.buffer()],
             vec![trusted_root.buffer(), trusted_root.buffer()],
+            vec![
+                untrusted_root.buffer(),
+                untrusted_root.buffer(),
+                trusted_root.buffer(),
+            ],
         ] {
             OmicronRepo::load(&logctx.log, &repo_dir, trust_store)
                 .await


### PR DESCRIPTION
The control flow here incorrectly diverges if a candidate trust root fails to verify a repository and a previous candidate already failed. (In other words: it works with two trust roots, but potentially not with three, depending on ordering.) The conditional should have been inside the expression, not the match arm guard; the conditional is unimportant and has been removed altogether.