### PR TITLE
Make fake BORD and SIGN values a little more realistic

### DIFF
--- a/artifact/src/kind.rs
+++ b/artifact/src/kind.rs
@@ -246,6 +246,36 @@ impl KnownArtifactKind {
     pub fn iter() -> KnownArtifactKindIter {
         <Self as IntoEnumIterator>::iter()
     }
+
+    /// For fake artifacts we generate for tests, what `SIGN` value do we insert
+    /// in the Hubris caboose for this artifact kind?
+    pub fn fake_artifact_hubris_sign(&self) -> Option<String> {
+        match self {
+            // Only RoT and RoT bootloader artifacts are signed. We want to use
+            // a distinct sign value for kind of system, just like real systems
+            // have.
+            KnownArtifactKind::GimletRot
+            | KnownArtifactKind::GimletRotBootloader => {
+                Some("sign-gimlet".to_string())
+            }
+            KnownArtifactKind::SwitchRot
+            | KnownArtifactKind::SwitchRotBootloader => {
+                Some("sign-switch".to_string())
+            }
+            KnownArtifactKind::PscRot | KnownArtifactKind::PscRotBootloader => {
+                Some("sign-psc".to_string())
+            }
+
+            KnownArtifactKind::GimletSp
+            | KnownArtifactKind::Host
+            | KnownArtifactKind::Trampoline
+            | KnownArtifactKind::InstallinatorDocument
+            | KnownArtifactKind::ControlPlane
+            | KnownArtifactKind::Zone
+            | KnownArtifactKind::PscSp
+            | KnownArtifactKind::SwitchSp => None,
+        }
+    }
 }
 
 #[derive(Debug, Error)]

--- a/lib/src/assemble/manifest.rs
+++ b/lib/src/assemble/manifest.rs
@@ -461,8 +461,11 @@ impl<'a> FakeDataAttributes<'a> {
         };
 
         let caboose = {
+            // We use a fake git commit that contains `self.kind` to ensure that
+            // the artifacts we produce are distinct for each `kind`, even if
+            // all the other caboose fields are identical.
             let mut builder = CabooseBuilder::default()
-                .git_commit("this-is-fake-data")
+                .git_commit(format!("this-is-a-fake-{}", self.kind))
                 .board(board)
                 .name(board)
                 .version(self.version.to_string());

--- a/lib/src/assemble/manifest.rs
+++ b/lib/src/assemble/manifest.rs
@@ -427,9 +427,6 @@ impl<'a> FakeDataAttributes<'a> {
         use hubtools::{CabooseBuilder, HubrisArchiveBuilder};
 
         let board = match self.kind {
-            KnownArtifactKind::GimletRotBootloader
-            | KnownArtifactKind::PscRotBootloader
-            | KnownArtifactKind::SwitchRotBootloader => "SimRotStage0",
             // non-Hubris artifacts: just make fake data
             KnownArtifactKind::Host
             | KnownArtifactKind::Trampoline
@@ -447,27 +444,35 @@ impl<'a> FakeDataAttributes<'a> {
                 );
             }
 
-            // hubris artifacts: build a fake archive (SimGimletSp and
+            // In production, all the bootloaders and RoTs claim to have the
+            // same board (currently: `oxide-rot-1`). Let's do that here too.
+            KnownArtifactKind::GimletRotBootloader
+            | KnownArtifactKind::PscRotBootloader
+            | KnownArtifactKind::SwitchRotBootloader
+            | KnownArtifactKind::GimletRot
+            | KnownArtifactKind::PscRot
+            | KnownArtifactKind::SwitchRot => "SimRot",
+
+            // SP artifacts: build a fake archive (SimGimletSp and
             // SimGimletRot are used by sp-sim)
             KnownArtifactKind::GimletSp => "SimGimletSp",
-            KnownArtifactKind::GimletRot => "SimRot",
-            KnownArtifactKind::PscSp => "fake-psc-sp",
-            KnownArtifactKind::PscRot => "fake-psc-rot",
             KnownArtifactKind::SwitchSp => "SimSidecarSp",
-            KnownArtifactKind::SwitchRot => "SimRot",
+            KnownArtifactKind::PscSp => "SimPscSp",
         };
 
-        // For our purposes sign = board represents what we want for the RoT
-        // and we don't care about the sign value for the SP
-        // We now have an assumption that board == name for our production
-        // images
-        let caboose = CabooseBuilder::default()
-            .git_commit("this-is-fake-data")
-            .board(board)
-            .version(self.version.to_string())
-            .name(board)
-            .sign(board)
-            .build();
+        let caboose = {
+            let mut builder = CabooseBuilder::default()
+                .git_commit("this-is-fake-data")
+                .board(board)
+                .name(board)
+                .version(self.version.to_string());
+
+            if let Some(sign) = self.kind.fake_artifact_hubris_sign() {
+                builder = builder.sign(sign);
+            }
+
+            builder.build()
+        };
 
         let mut builder = HubrisArchiveBuilder::with_fake_image();
         builder.write_caboose(caboose.as_slice()).unwrap();


### PR DESCRIPTION
When trying Reconfigurator-based updates on a racklette today with a real TUF repo, the planner skipped all the RoT bootloader and RoT updates because none of the artifact `name`s matched the artifact `board`s. Artifact name matching board is a property that's true for the SP in both fake data and production, but is only true for the bootloader and RoT in the fake data generated by tufaceous.

This PR changes the fake data to be more consistent with real data:

* TUF artifact `name` does not necessarily match hubris caboose `name`
* All RoTs and RoT bootloaders report the same `BORD`
* Each target type (sled, switch, psc) has distinct `SIGN` values despite the `BORD` values matching

As written this would break a bunch of omicron tests (which it should! things aren't working in prod either). I'll open a PR with the corresponding changes there shortly.