### PR TITLE
expose v1 artifacts for installinator

### DIFF
--- a/artifact/src/installinator.rs
+++ b/artifact/src/installinator.rs
@@ -43,8 +43,6 @@ use crate::ArtifactVersion;
 /// own backwards compatibility code, which some temporary code in this module
 /// supports:
 ///
-/// - `name` is accepted as an alias for [`InstallinatorArtifact::file_name`].
-///   We renamed this field in Tufaceous v2 for clarity.
 /// - `ControlPlane` is an accepted variant for [`InstallinatorArtifactKind`].
 ///   This indicates to Installinator that an older version of Wicket was used
 ///   to read the repository, and that it will need to fetch the composite
@@ -82,8 +80,11 @@ pub struct InstallinatorArtifact {
     pub hash: ArtifactHash,
     /// A file name without directory separators; not necessarily the target
     /// name.
-    // (temporary alias; see "v1 compatibility notes" above)
-    #[serde(alias = "name")]
+    ///
+    /// This is named `name` in the serialized document in order to retain
+    /// compatibility with older versions of Installinator, allowing us to
+    /// downgrade clean-slated development environments with mupdate.
+    #[serde(rename = "name")]
     pub file_name: String,
 }
 

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -27,6 +27,7 @@ use tough::schema::Target;
 use tufaceous_artifact::Artifact;
 use tufaceous_artifact::ArtifactHash;
 use tufaceous_artifact::ArtifactSet;
+use tufaceous_artifact::ArtifactVersion;
 use tufaceous_artifact::KnownArtifactTags;
 use tufaceous_artifact::Metadata;
 use tufaceous_artifact::artifact_set::GetError;
@@ -51,6 +52,15 @@ pub struct Repository {
     artifacts: ArtifactSet,
     artifact_data: BTreeMap<Artifact, ArtifactData>,
     metadata: BTreeMap<String, String>,
+
+    /// If this is a v1 repo, this contains the hash of the original
+    /// Installinator document (instead of the converted-to-v2 document).
+    installinator_v1_document: Option<ArtifactHash>,
+    /// If this is a v1 repo, this contains artifacts that allow reading
+    /// the original Installinator document (instead of the converted-to-v2
+    /// document), as well as the original control plane tarball referenced by
+    /// that document.
+    installinator_v1_artifacts: Vec<InstallinatorV1Artifact>,
 
     // These are set directly by the ZIP archive convenience methods in the
     // loader module.
@@ -126,6 +136,10 @@ impl Repository {
                     artifacts: partial.artifacts,
                     artifact_data: partial.artifact_data,
                     metadata: BTreeMap::new(),
+                    installinator_v1_document: partial
+                        .installinator_v1_document,
+                    installinator_v1_artifacts: partial
+                        .installinator_v1_artifacts,
                     archive_path: None,
                     archive_sha256: None,
                 });
@@ -156,6 +170,8 @@ impl Repository {
             artifacts,
             artifact_data,
             metadata,
+            installinator_v1_document: None,
+            installinator_v1_artifacts: Vec::new(),
             archive_path: None,
             archive_sha256: None,
         })
@@ -290,7 +306,11 @@ impl Repository {
         tags: &KnownArtifactTags,
     ) -> Result<ArtifactHandle, GetError> {
         let artifact = self.artifacts.get_only(tags)?.clone();
-        Ok(ArtifactHandle { artifact, repo: Arc::clone(self) })
+        Ok(ArtifactHandle {
+            artifact,
+            repo: Arc::clone(self),
+            installinator_v1_target_name: None,
+        })
     }
 
     /// Returns an iterator of [`ArtifactHandle`]s for every artifact
@@ -300,10 +320,38 @@ impl Repository {
     /// together in a struct as a convenience. The repository must be wrapped in
     /// [`Arc`] to call this method.
     pub fn handles(self: &Arc<Self>) -> impl Iterator<Item = ArtifactHandle> {
-        self.artifacts
-            .iter()
-            .cloned()
-            .map(|artifact| ArtifactHandle { artifact, repo: Arc::clone(self) })
+        self.artifacts.iter().cloned().map(|artifact| ArtifactHandle {
+            artifact,
+            repo: Arc::clone(self),
+            installinator_v1_target_name: None,
+        })
+    }
+
+    /// If this was a v1 repository, returns the hash of the original
+    /// Installinator document (instead of the converted-to-v2 document).
+    pub fn installinator_v1_document(&self) -> Option<ArtifactHash> {
+        self.installinator_v1_document.as_ref().copied()
+    }
+
+    /// If this was a v1 repository, returns an iterator of [`ArtifactHandle`]
+    /// that can be used to read the original Installinator document or control
+    /// plane tarball.
+    ///
+    /// Note that the `Artifact` returned by the handle has no tags as it is not
+    /// a valid artifact.
+    pub fn installinator_v1_handles(
+        self: &Arc<Self>,
+    ) -> impl Iterator<Item = ArtifactHandle> {
+        self.installinator_v1_artifacts.iter().map(|artifact| ArtifactHandle {
+            artifact: Artifact {
+                version: artifact.version.clone(),
+                tags: BTreeMap::new(),
+                hash: artifact.hash,
+                length: artifact.length,
+            },
+            repo: Arc::clone(self),
+            installinator_v1_target_name: Some(artifact.target_name.clone()),
+        })
     }
 
     /// Reads all targets in the repository and verifies they have the correct
@@ -396,6 +444,14 @@ impl ArtifactData {
     }
 }
 
+#[derive(Debug, Clone)]
+struct InstallinatorV1Artifact {
+    version: ArtifactVersion,
+    hash: ArtifactHash,
+    length: u64,
+    target_name: String,
+}
+
 /// An [`Artifact`] and the [`Repository`] it belongs to, for convenience to
 /// code that works at the artifact level but needs to read the artifact data
 /// from the repository.
@@ -405,6 +461,11 @@ impl ArtifactData {
 pub struct ArtifactHandle {
     artifact: Artifact,
     repo: Arc<Repository>,
+
+    /// If `Some`, this is not a "real" artifact but instead was generated
+    /// by [`Repository::installinator_v1_artifacts`], and `artifact.tags` is
+    /// empty.
+    installinator_v1_target_name: Option<String>,
 }
 
 impl ArtifactHandle {
@@ -421,7 +482,11 @@ impl ArtifactHandle {
 
     /// Read this artifact from its repository.
     pub async fn stream(&self) -> Result<TargetStream, Error> {
-        self.repo.read_artifact(&self.artifact).await
+        if let Some(target_name) = &self.installinator_v1_target_name {
+            self.repo.read_target(target_name).await
+        } else {
+            self.repo.read_artifact(&self.artifact).await
+        }
     }
 }
 

--- a/lib/src/repo/v1.rs
+++ b/lib/src/repo/v1.rs
@@ -56,6 +56,7 @@ use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::error::try_path;
 use crate::repo::ArtifactData;
+use crate::repo::InstallinatorV1Artifact;
 use crate::repo::read_target;
 use crate::repo::read_target_json;
 use crate::repo::read_target_vec;
@@ -66,6 +67,8 @@ pub(super) struct PartialRepository {
     pub(super) system_version: Version,
     pub(super) artifacts: ArtifactSet,
     pub(super) artifact_data: BTreeMap<Artifact, ArtifactData>,
+    pub(super) installinator_v1_document: Option<ArtifactHash>,
+    pub(super) installinator_v1_artifacts: Vec<InstallinatorV1Artifact>,
 }
 
 impl PartialRepository {
@@ -98,6 +101,8 @@ pub(crate) async fn from_loaded(
         system_version,
         artifacts: ArtifactSet::default(),
         artifact_data: BTreeMap::new(),
+        installinator_v1_document: None,
+        installinator_v1_artifacts: Vec::new(),
     };
     let mut installinator_document = None;
     for V1Artifact { version, kind, target } in v1_artifacts {
@@ -214,6 +219,14 @@ pub(crate) async fn from_loaded(
             }
 
             V1KnownArtifactKind::ControlPlane => {
+                partial.installinator_v1_artifacts.push(
+                    InstallinatorV1Artifact {
+                        version,
+                        hash,
+                        length,
+                        target_name: target.clone(),
+                    },
+                );
                 CompositeArtifact::unpack(tuf_repo, target)
                     .await?
                     .read_control_plane(&mut partial)
@@ -226,6 +239,15 @@ pub(crate) async fn from_loaded(
             // for the v2 artifacts once all of the potential artifacts are
             // extracted.
             V1KnownArtifactKind::InstallinatorDocument => {
+                partial.installinator_v1_document = Some(hash);
+                partial.installinator_v1_artifacts.push(
+                    InstallinatorV1Artifact {
+                        version: version.clone(),
+                        hash,
+                        length,
+                        target_name: target.clone(),
+                    },
+                );
                 installinator_document = Some((version, target));
                 continue;
             }

--- a/lib/tests/v1_compatibility.rs
+++ b/lib/tests/v1_compatibility.rs
@@ -96,7 +96,7 @@ async fn v1_fake() -> Result<(), Error> {
         .get_only(&KnownArtifactTags::InstallinatorDocument)
         .unwrap();
     let doc_json = repo
-        .read_artifact(&artifact)
+        .read_artifact(artifact)
         .await?
         .map_ok(Vec::from)
         .try_concat()

--- a/lib/tests/v1_compatibility.rs
+++ b/lib/tests/v1_compatibility.rs
@@ -2,11 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
 use camino::Utf8Path;
+use futures_util::TryStreamExt;
 use tufaceous::ExpirationEnforcement;
 use tufaceous::RepositoryLoader;
 use tufaceous::error::Error;
 use tufaceous_artifact::ArtifactSet;
+use tufaceous_artifact::InstallinatorDocument;
 use tufaceous_artifact::KnownArtifactTags;
 use tufaceous_artifact::OsBoard;
 use tufaceous_artifact::OsPhase1Tags;
@@ -25,12 +30,14 @@ async fn v1_fake() -> Result<(), Error> {
     let path = Utf8Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/data/v1-fake.zip");
 
-    let repo = RepositoryLoader::new()
-        .expiration_enforcement(ExpirationEnforcement::Unsafe)
-        .unsafe_blindly_trust_repo()
-        .v1_compatibility(true)
-        .load_zip_path(path, &log)
-        .await?;
+    let repo = Arc::new(
+        RepositoryLoader::new()
+            .expiration_enforcement(ExpirationEnforcement::Unsafe)
+            .unsafe_blindly_trust_repo()
+            .v1_compatibility(true)
+            .load_zip_path(path, &log)
+            .await?,
+    );
     let parallelism = std::thread::available_parallelism().unwrap().get();
     repo.verify_targets(parallelism).await?;
 
@@ -76,6 +83,54 @@ async fn v1_fake() -> Result<(), Error> {
         .collect::<ArtifactSet>();
     // And there should be no unexpected artifacts:
     assert_eq!(&seen, repo.artifacts());
+
+    // The Installinator document should be regenerated to only reference
+    // v2 artifacts.
+    let mut hashes = repo
+        .artifacts()
+        .iter()
+        .map(|artifact| artifact.hash)
+        .collect::<BTreeSet<_>>();
+    let artifact = repo
+        .artifacts()
+        .get_only(&KnownArtifactTags::InstallinatorDocument)
+        .unwrap();
+    let doc_json = repo
+        .read_artifact(&artifact)
+        .await?
+        .map_ok(Vec::from)
+        .try_concat()
+        .await?;
+    let doc: InstallinatorDocument = serde_json::from_slice(&doc_json).unwrap();
+    for artifact in doc.artifacts {
+        assert!(
+            hashes.contains(&artifact.hash),
+            "converted Installinator document references non-existent hash {}",
+            artifact.hash
+        );
+    }
+
+    // The original Installinator document should be accessible, and may
+    // reference either v2 or v1-only artifacts.
+    hashes.extend(
+        repo.installinator_v1_handles().map(|handle| handle.artifact().hash),
+    );
+    let handle = repo
+        .installinator_v1_handles()
+        .find(|handle| {
+            handle.artifact().hash == repo.installinator_v1_document().unwrap()
+        })
+        .unwrap();
+    let doc_json =
+        handle.stream().await?.map_ok(Vec::from).try_concat().await?;
+    let doc: InstallinatorDocument = serde_json::from_slice(&doc_json).unwrap();
+    for artifact in doc.artifacts {
+        assert!(
+            hashes.contains(&artifact.hash),
+            "original Installinator document references non-existent hash {}",
+            artifact.hash
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
These changes are to allow a v2-aware Wicket to be able to work with a v2-unaware Installinator, allowing for the usual "reset and downgrade" flow on our development environments. [The proposed change to Wicket](https://github.com/oxidecomputer/omicron/pull/10755/changes/7e63b23dacf9ed318dc270fb9cbaddb1cadfa34c) will be to always serve a v1 Installinator document if a user uploaded a v1 repo, because v2-aware Installinator has to be able to deal with v1 Installinator documents regardless.

Given this proposed change, why still have the v1 compatibility code that regenerates the Installinator document using the unpacked artifacts? Well, it's not harming anything to keep it, and it means that the Installinator document written to the repo depot by Nexus references artifacts that are accessible in the repo depot. (The full control plane tarball has never been available in the repo depot.) I don't expect Nexus will drive Installinator any time soon but we may as well keep that in mind.

Wicket wants to be able to use an `ArtifactHandle` to stream artifacts by hash, so that's the interface we provide.

This also reverts the change in v2 that renamed `name` to `file_name` in the serialized Installinator document; the Rust field name stays the same but is renamed to `name` in the JSON form. This is not actually necessary given the changes I'm making in Wicket but I've already tested it with this change and I don't particularly mind it.